### PR TITLE
Re-adding working shapes plus some new ones

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -110,6 +110,8 @@ The available actions for brushes are:
     that match `replacement` (block or tag), if given.
 - `cuboid <block> <x> <y> <z> [replacement]` -> creates a cuboid out of `block` and with side lengths `x`, `y` and `z`, 
     replacing only blocks that match `replacement` (block or tag), if given.
+- `diamond <block> <diagonal_size> [replacement]` -> creates a regular diamond (octahedron) out of `block` and with diagonals
+    given by `diagonal_size`, replacing only blocks that match `replacement` (block or tag), if given.
 - `sphere <block> <radius> [replacement]` -> creates a sphere out of `block` and with `radius`, replacing only blocks that
     match `replacement` (block or tag), if given.
 - `ellipsoid <block> <x_radius> <y_radius> <z_radius> [replacement]` -> creates an ellipsoid with different radii on each
@@ -118,14 +120,22 @@ The available actions for brushes are:
     `height` along `axis` (if given; else, defaults to `y` for a vertical cylinder), replacing only blocks that match 
     `replacement` (block or tag), if given.
 - `cone <block> <radius> <height> [signed_axis] [replacement]` -> creates a cone out of `block` and with `radius` and 
-    `height` along `signed_axis` (if given; else, defaults to `+y` for a vertical cone pointing up), replacing only blocks
-    that match `replacement` (block or tag), if given.
-- `prism_polygon <block> <radius> <height> <points> [axis] [rotation] [replacement]` -> generates a prism with the base
+    `height` with its point pointing into `signed_axis` (if given; else, defaults to `+y` for a vertical cone pointing up),
+    replacing only blocks that match `replacement` (block or tag), if given.
+- `cone <block> <side_length> <height> [signed_axis] [replacement]` -> creates an pyramid out of `block` with square base
+    with the given `side_length`. `signed_axis` and `replacement` work as above.
+- `polygon prism <block> <radius> <height> <points> [axis] [rotation] [replacement]` -> generates a prism with the base
     of a regular polygon inscribed in a circle of `radius` with `points` amount of sides and height `height` along `axis`.
     Optionally, it can be rotated from its base orientation.
-- `prism_star <block> <outer_radius> <inner_radius> <height> <points> [axis] [rotation] [replacement]` -> generates a 
+- `polygon pyramid <block> <radius> <height> <points> [signed_axis] [rotation] [replacement]` -> generates a pyramid with
+    the base in the shape of a regular polygon and the point pointing into `signed_axis`. All polygon parameters work as 
+    above.
+- `star prism <block> <outer_radius> <inner_radius> <height> <points> [axis] [rotation] [replacement]` -> generates a 
     star whose points touch a circle of radius `outer_radius` with `points` amount of points. Said star is the base 
     for a prism of height `height` along `axis`. Optionally, it can be rotated from its base orientation.
+- `star pyramid <block> <outer_radius> <inner_radius> <height> <points> [axis] [rotation] [replacement]` -> generates a 
+    pyramid with the base in the shape of a regular star and the point pointing into `signed_axis`. All star parameters
+    work as above.
 - `line <block> [length] [replacement]` -> creates a line out of `block` between the player and the clicked block, replacing
     only blocks that match `replacement` (block or tag), if given. If `length` is given, the length of the line is fixed,
     and it only uses the clicked block to get the direction of the line.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ there's also an in-game help menu.
 
 For more detailed instructions on how to install scarpet scripts, check: https://github.com/gnembon/fabric-carpet/wiki/Installing-carpet-scripts-in-your-world
 
-If you want to contribute, make sure you have read [the contributions manual](/CONTRIBUTING.md) first. This is important
+If you want to contribute, make sure you have read [the contributions manual](/docs/CONTRIBUTING.md) first. This is important
 to maintain the code structure and formatting, to make it easier for future contributions. 
 
 NB: It's good practice to read this before every contribution.

--- a/se.sc
+++ b/se.sc
@@ -1427,17 +1427,7 @@ global_brush_shapes={
             [perimeter, interior] = _make_circle(radius, inner, axis, pos);
             offset = _get_prism_offset(height, axis);
 	    
-            if(flags~'h',
-	        //place two discs for the caps and go around the perimeter placing columns of blocks for the walls
-                for(perimeter, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {}) ));
-                for(interior,
-                    set_block(_+offset, block, replacement, flags, {});
-                    set_block(_-offset, block, replacement, flags, {});
-                ),
-		    //place a column of blocks for each point in the disc
-                for(interior, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {})))
-            );
-
+            _prism_generic(perimeter, interior, height, axis, block, replacement, flags);
             add_to_history('action_cylinder',player())
         ),
     'paste'->_(pos, args, flags)->(
@@ -1565,17 +1555,7 @@ global_brush_shapes={
             // fill the interior of the perimeter to get a solid cap
             interior = _flood_fill_shape(perimeter, center, axis, {});
             
-            offset = _get_prism_offset(height, axis);
-            if(flags~'h',
-            //place two solid polygons for the caps and go around the perimeter placing columns of blocks for the walls
-                for(perimeter, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {}) ));
-                for(interior,
-                    set_block(_+offset, block, replacement, flags, {});
-                    set_block(_-offset, block, replacement, flags, {});
-                ),
-            //place a column of blocks for each point in the (solid) polygon
-                for(interior, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {})))
-            );
+            _prism_generic(perimeter, interior, height, axis, block, replacement, flags);
             add_to_history('action_prism_polygon',player());
         ),
 
@@ -1607,7 +1587,7 @@ global_brush_shapes={
                 );
                 [perimeter, interior]
             );
-            // _generic_pyramid doesn't need the ammount of sides of the polygon or the rotation
+            // _pyramid_generic doesn't need the ammount of sides of the polygon or the rotation
             newargs = [block, radius, height, signed_axis, replacement];
             _pyramid_generic(pos, newargs, flags);   
 
@@ -1633,17 +1613,7 @@ global_brush_shapes={
             // fill the interior of the perimeter to get a solid cap
             interior = _flood_fill_shape(perimeter, center, axis, {});
         
-            offset = _get_prism_offset(height, axis);
-            if(flags~'h',
-            //place two solid stars for the caps and go around the perimeter placing columns of blocks for the walls
-                for(perimeter, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {}) ));
-                for(interior,
-                    set_block(_+offset, block, replacement, flags, {});
-                    set_block(_-offset, block, replacement, flags, {});
-                ),
-            //place a column of blocks for each point in the (solid) star
-                for(interior, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {})))
-            );
+            _prism_generic(perimeter, interior, height, axis, block, replacement, flags);
             add_to_history('action_prism_polygon',player())
         ),
 
@@ -1679,7 +1649,7 @@ global_brush_shapes={
                 );
                 [perimeter, interior]
             );
-            // _generic_pyramid doesn't need the ammount of points of the star or the rotation
+            // _pyramid_generic doesn't need the ammount of points of the star or the rotation
             newargs = [block, radius, height, signed_axis, replacement];
             _pyramid_generic(pos, newargs, flags);   
 
@@ -1766,6 +1736,23 @@ _cuboid(pos, args, flags) -> (
 );
 
 _sq_distance(p1, p2) -> reduce(p1-p2, _a + _*_, 0);
+
+// generate a prism with caps given by <interior>. If the prism is hollow, it uses <perimeter> to
+// generate the walls.
+_prism_generic(perimeter, interior, height, axis, block, replacement, flags) -> (
+    offset = _get_prism_offset(height, axis);
+    if(flags~'h',
+    //place two solid polygons for the caps and go around the perimeter placing columns of blocks for the walls
+        for(perimeter, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {}) ));
+        for(interior,
+            set_block(_+offset, block, replacement, flags, {});
+            set_block(_-offset, block, replacement, flags, {});
+        ),
+    //place a column of blocks for each point in the (solid) polygon
+        for(interior, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {})))
+    );
+
+);
 
 // generate a pyramid of arbitrary base shape (so cones, pyramids, whatever you like)
 // to use this function, a pyramid-maker function needs to define _shape_maker, which
@@ -2016,7 +2003,7 @@ _interlace_lists(l1, l2) -> (
 );
 
 _get_prism_offset(height, axis) -> (
-    // returns offset half column given axis
+    // returns an offset of half height given axis
     halfheight = (height-1)/2;
     if(
         axis=='x', [halfheight, 0, 0],

--- a/se.sc
+++ b/se.sc
@@ -1065,7 +1065,7 @@ global_lang_keys = global_default_lang = {
     'brush_new' ->			'w Registerd new %s brush to %s', //item, action
     'brush_list_header' ->              'bc === Current brushes are ===',
     'brush_extra_info' ->               'ig For detailed info on a brush click the [i] icon',
-    'brush_extra_clear' ->               'ig To unregister an item as a brush, click the [X] icon',
+    'brush_extra_clear' ->              'ig To unregister an item as a brush, click the [X] icon',
     'brush_empty_list' ->               'ig You don\'t have any brushes registered',
     'brush_new_reach' ->                'w Brush reach was set to %d blocks',
     'brush_reach' ->                    'w Brush reach is currently %d blocks', // reach
@@ -1095,7 +1095,7 @@ global_lang_keys = global_default_lang = {
     //Block-setting actions
     'action_cube'->                'cube',
     'action_cuboid' ->             'cuboid',
-    'action_diamond' ->             'diamond',
+    'action_diamond' ->            'diamond',
     'action_ellipsoid' ->          'ellipsoid',
     'action_sphere' ->             'sphere',
     'action_cylinder' ->           'cylinder',

--- a/se.sc
+++ b/se.sc
@@ -145,13 +145,13 @@ base_commands_map = [
         [2, 'help_cmd_brush_cone', 'help_cmd_brush_generic', null]],
     ['brush cone <block> <radius> <height> <saxis> <replacement> f <flag>', _(block, radius, height, axis, replacement, flags) -> brush('cone', flags, block, radius, height, axis, replacement), false],
 
-    ['brush pyramid <block> <radius> <height>', _(block, radius, height) -> brush('cone', null, block, radius, height, '+y', null), false],
-    ['brush pyramid <block> <radius> <height> f <flag>', _(block, radius, height, flags) -> brush('cone', flags, block, radius, height, '+y', null), false],
-    ['brush pyramid <block> <radius> <height> <saxis>', _(block, radius, height, axis) -> brush('cone', null, block, radius, height, axis, null), false],
-    ['brush pyramid <block> <radius> <height> <saxis> f <flag>', _(block, radius, height, axis, flags) -> brush('cone', flags, block, radius, height, axis, null), false],
-    ['brush pyramid <block> <radius> <height> <saxis> <replacement>', _(block, radius, height, axis, replacement) -> brush('cone', null, block, radius, height, axis, replacement),
+    ['brush pyramid <block> <side_size> <height>', _(block, radius, height) -> brush('cone', null, block, radius, height, '+y', null), false],
+    ['brush pyramid <block> <side_size> <height> f <flag>', _(block, radius, height, flags) -> brush('cone', flags, block, radius, height, '+y', null), false],
+    ['brush pyramid <block> <side_size> <height> <saxis>', _(block, radius, height, axis) -> brush('cone', null, block, radius, height, axis, null), false],
+    ['brush pyramid <block> <side_size> <height> <saxis> f <flag>', _(block, radius, height, axis, flags) -> brush('cone', flags, block, radius, height, axis, null), false],
+    ['brush pyramid <block> <side_size> <height> <saxis> <replacement>', _(block, radius, height, axis, replacement) -> brush('cone', null, block, radius, height, axis, replacement),
         [2, 'help_cmd_brush_cone', 'help_cmd_brush_generic', null]],
-    ['brush pyramid <block> <radius> <height> <saxis> <replacement> f <flag>', _(block, radius, height, axis, replacement, flags) -> brush('cone', flags, block, radius, height, axis, replacement), false],
+    ['brush pyramid <block> <side_size> <height> <saxis> <replacement> f <flag>', _(block, radius, height, axis, replacement, flags) -> brush('cone', flags, block, radius, height, axis, replacement), false],
     ['brush flood <block>', _(block) -> brush('flood', null, block, null, null), false],
     ['brush flood <block> f <flag>', _(block, flags) -> brush('flood', flags, block, null, null), false],
     ['brush flood <block> <radius>', _(block, radius) -> brush('flood', null, block, radius, null), false],
@@ -271,11 +271,11 @@ base_commands_map = [
     ['shape cone <pos> <block> <radius> <height> <saxis> f <flag>', _(pos, block, radius, height, axis, flags) -> shape('cone', pos, [block, radius, height, axis, null], flags), false],
     ['shape cone <pos> <block> <radius> <height> <saxis> <replacement>', _(pos, block, radius, height, axis, replacement) -> shape('cone', pos, [block, radius, height, axis, replacement], null),
         [2, 'help_cmd_brush_cone', 'help_cmd_brush_generic', null]],
-    ['shape pyramid <pos> <block> <radius> <height>', _(pos, block, radius, height) -> shape('pyramid', pos, [block, radius, height, '+y', null], null), false],
-    ['shape pyramid <pos> <block> <radius> <height> f <flag>', _(pos, block, radius, height, flags) -> shape('pyramid', pos, [block, radius, height, '+y', null], flags), false],
-    ['shape pyramid <pos> <block> <radius> <height> <saxis>', _(pos, block, radius, height, axis) -> shape('pyramid', pos, [block, radius, height, axis, null], null), false],
-    ['shape pyramid <pos> <block> <radius> <height> <saxis> f <flag>', _(pos, block, radius, height, axis, flags) -> shape('pyramid', pos, [block, radius, height, axis, null], flags), false],
-    ['shape pyramid <pos> <block> <radius> <height> <saxis> <replacement>', _(pos, block, radius, height, axis, replacement) -> shape('pyramid', pos, [block, radius, height, axis, replacement], null),
+    ['shape pyramid <pos> <block> <side_size> <height>', _(pos, block, radius, height) -> shape('pyramid', pos, [block, radius, height, '+y', null], null), false],
+    ['shape pyramid <pos> <block> <side_size> <height> f <flag>', _(pos, block, radius, height, flags) -> shape('pyramid', pos, [block, radius, height, '+y', null], flags), false],
+    ['shape pyramid <pos> <block> <side_size> <height> <saxis>', _(pos, block, radius, height, axis) -> shape('pyramid', pos, [block, radius, height, axis, null], null), false],
+    ['shape pyramid <pos> <block> <side_size> <height> <saxis> f <flag>', _(pos, block, radius, height, axis, flags) -> shape('pyramid', pos, [block, radius, height, axis, null], flags), false],
+    ['shape pyramid <pos> <block> <side_size> <height> <saxis> <replacement>', _(pos, block, radius, height, axis, replacement) -> shape('pyramid', pos, [block, radius, height, axis, replacement], null),
         [2, 'help_cmd_brush_cone', 'help_cmd_brush_generic', null]],
     ['shape prism_polygon <pos> <block> <radius> <height> <points>',
         _(pos, block, radius, height, n_points) -> shape('prism_polygon', pos, [block, radius, height, n_points, 'y', 0, null], null), false],
@@ -1244,24 +1244,24 @@ global_brush_shapes={
             add_to_history('action_cone',player())
         ),
     'pyramid'->_(pos, args, flags)->(
-            [block, radius, height, signed_axis, replacement] = args;
-            roh = radius / height; //radius over height
-            _shape_maker(h, hollow, axis, base, outer(radius), outer(roh), outer(height)) -> (
-                r = radius - roh*h;
+            [block, sidelength, height, signed_axis, replacement] = args;
+            roh = sidelength / height; //radius over height
+            _shape_maker(h, hollow, axis, base, outer(sidelength), outer(roh), outer(height)) -> (
+                r = sidelength - roh*h;
                 inner = if(
                     !hollow, //only use discs
                         null,
-                    radius > height, 
-                        radius - roh*(h+1), 
+                    sidelength > 2*height, 
+                        floor(sidelength) - roh*(h+1), 
                     //else
-                        r-1
+                        floor(r)-2
                 );
-                if(r<=0.5,
+                if(r<=1,
                     [[base], [base]],
-                    _make_circle(r, inner, axis, base);
+                    _make_square(r, inner, axis, base);
                 );
             );
-            _pyramid_generic(pos, args, flags);            
+            _pyramid_generic(pos, args, flags);   
 
             add_to_history('action_pyramid',player())
         ),
@@ -1533,7 +1533,6 @@ _pyramid_generic(pos, args, flags) -> (
 
     loop(height,
         h = _;
-        print(h);
         [perimeter, interior] = _shape_maker(h, hollow, axis, base);
         if(h==0 || !hollow, 
             for(interior, set_block(_+offset*h, block, replacement, flags, {})),  //closed bottom
@@ -1566,7 +1565,6 @@ _fill_shape(from, to, block, replacement, flags) -> (
 
 );
 
-
 _make_flat_circle(radius, inner) -> (
     circle_set = {};
     disc_set = {};
@@ -1577,26 +1575,18 @@ _make_flat_circle(radius, inner) -> (
             y = _;
             if( 
                 x*x+y*y<radius*radius,
-                disc_set += [x, y];
-                disc_set += [y, x];
-                if(x*x+y*y>=inner*inner ,
-                    circle_set += [x, y];
-                    circle_set += [y, x];
+                for(_all_reflections(x, y), disc_set += _);
+                if(inner!=null && x*x+y*y>=inner*inner ,
+                    for(_all_reflections(x, y), circle_set += _);
                 )
             )
         )
     );
-    for(_rotated90(circle_set), circle_set += _);
-    for(_rotated90(_rotated90(circle_set)), circle_set += _);
-
-    for(_rotated90(disc_set), disc_set += _);
-    for(_rotated90(_rotated90(disc_set)), disc_set += _);
-
     [circle_set, disc_set]
 );
 
 _make_circle(radius, inner, axis, center) -> (
-    //generates a disco with given <radius> and a circle or ring with inner radius <inner>
+    //generates a disc with given <radius> and a circle or ring with inner radius <inner>
     //the face of the disc will point towards <axis> and will be centered in about <center>
     if( //this takes in a 2-list and returns a 3-list woth a 0 interleaved somewhere depending on axis
         axis=='x', _2D_to_3D(u, v, w) -> [w, u, v],
@@ -1611,10 +1601,47 @@ _make_circle(radius, inner, axis, center) -> (
     [circle, disc]
 );
 
-_rotated90(list_to_rotate) -> ( //rotates 90 degrees
-    map(list_to_rotate, [_:1, -_:0])
+_make_flat_square(sidelength, inner) -> (
+    interior = {};
+    perimeter = {};
+
+    hl = (sidelength+1)/2; //half side length
+    hi = (inner+1)/2; //half inner side length
+    loop(round(hl),
+        x = _;
+        loop(x+1,
+            y = _;
+            for(_all_reflections(x, y), interior += _);
+            if(inner!=null && x>=hi, //y <= x always hold, because I'm only looking at an eight of the square
+                for(_all_reflections(x, y), perimeter += _)
+            )
+        )
+    );
+    [interior, perimeter]
 );
 
+_make_square(sidelength, inner, axis, center) -> (
+
+    if( //this takes in a 2-list and returns a 3-list woth a 0 interleaved somewhere depending on axis
+        axis=='x', _2D_to_3D(u, v, w) -> [w, u, v],
+        axis=='y', _2D_to_3D(u, v, w) -> [u, w, v],
+        axis=='z', _2D_to_3D(u, v, w) -> [u, v, w],
+    );
+    [interior, perimeter] = _make_flat_square(sidelength, inner);
+    
+    perimeter = map(perimeter, center + _2D_to_3D(_:0, _:1, 0));
+    interior = map(interior, center + _2D_to_3D(_:0, _:1, 0));
+    [perimeter, interior]
+);
+
+_all_reflections(x, y) -> ( 
+    //this takes in a point in the first quarter plane under the x=y line and reflects it about
+    //that line, and reflects the resulting pair of points about all axes, resulting in 8 points
+    [
+        [x,y], [x,-y], [-x,y], [-x,-y],
+        [y,x], [y,-x], [-y,x], [-y,-x]
+    ]
+);
 
 fill_flat_circle(pos, offset, dr, orientation, block, hollow, replacement, flags)->(
     r = floor(dr);

--- a/se.sc
+++ b/se.sc
@@ -121,6 +121,11 @@ base_commands_map = [
     ['brush cuboid <block> <x_size> <y_size> <z_size> <replacement>', _(block, x_int, y_int, z_int, replacement) -> brush('cuboid', null, block, [x_int, y_int, z_int], replacement),
         [4, 'help_cmd_brush_cuboid', 'help_cmd_brush_generic', null]],
     ['brush cuboid <block> <x_size> <y_size> <z_size> <replacement> f <flag>', _(block, x_int, y_int, z_int, replacement, flags) -> brush('cuboid', flags, block, [x_int, y_int, z_int], replacement), false],
+    ['brush diamond <block> <size>', _(block, size_int) -> brush('diamond', null, block, size_int, null), false],
+    ['brush diamond <block> <size> f <flag>', _(block, size_int, flags) -> brush('diamond', flags, block, size_int, null), false],
+    ['brush diamond <block> <size> <replacement>', _(block, size_int, replacement) -> brush('diamond', null, block, size_int, replacement),
+        [2, 'help_cmd_brush_diamond', 'help_cmd_brush_generic', null]],
+    ['brush diamond <block> <size> <replacement> f <flag>', _(block, size_int, replacement, flags) -> brush('diamond', flags, block, size_int, replacement), false],
     ['brush sphere <block> <radius>', _(block, radius) -> brush('sphere', null, block, radius, null), false],
     ['brush sphere <block> <radius> f <flag>', _(block, radius, flags) -> brush('sphere', flags, block, radius, null), false],
     ['brush sphere <block> <radius> <replacement>', _(block, radius, replacement) -> brush('sphere', null, block, radius, replacement),
@@ -281,13 +286,17 @@ base_commands_map = [
     ['shape cube <pos> <block> <size>', _(pos, block, size_int) -> shape('cube', pos, [block, size_int, null], null), false],
     ['shape cube <pos> <block> <size> f <flag>', _(pos, block, size_int, flags) -> shape('cube', pos, [block, size_int, null], flags), false],
     ['shape cube <pos> <block> <size> <replacement>', _(pos, block, size_int, replacement) -> shape('cube', pos, [block, size_int, replacement], null),
-        [2, 'help_cmd_shape_cube', null, null]],
+        [2, 'help_cmd_brush_cube', null, null]],
     ['shape cube <pos> <block> <size> <replacement> f <flag>', _(pos, block, size_int, replacement, flags) -> shape('cube', pos, [block, size_int, replacement], flags), false],
     ['shape cuboid <pos> <block> <x_size> <y_size> <z_size>', _(pos, block, x_int, y_int, z_int) -> shape('cuboid', pos, [block, [x_int, y_int, z_int], null], null), false],
     ['shape cuboid <pos> <block> <x_size> <y_size> <z_size> f <flag>', _(pos, block, x_int, y_int, z_int, flags) -> shape('cuboid', pos, [block, [x_int, y_int, z_int], null], flags), false],
     ['shape cuboid <pos> <block> <x_size> <y_size> <z_size> <replacement>', _(pos, block, x_int, y_int, z_int, replacement) -> shape('cuboid', pos, [block, [x_int, y_int, z_int], replacement], null),
         [4, 'help_cmd_brush_cuboid', 'help_cmd_brush_generic', null]],
     ['shape cuboid <pos> <block> <x_size> <y_size> <z_size> <replacement> f <flag>', _(pos, block, x_int, y_int, z_int, replacement, flags) -> shape('cuboid', pos, [block, [x_int, y_int, z_int], replacement], flags), false],
+    ['shape diamond <pos> <block> <size>', _(pos, block, size_int) -> shape('diamond', pos, [block, size_int, null], null), false],
+    ['shape diamond <pos> <block> <size> f <flag>', _(pos, block, size_int, flags) -> shape('diamond', pos, [block, size_int, null], flags), false],
+    ['shape diamond <pos> <block> <size> <replacement>', _(pos, block, size_int, replacement) -> shape('diamond', pos, [block, size_int, replacement], null),
+        [2, 'help_cmd_brush_diamond', null, null]],
     ['shape sphere <pos> <block> <radius>', _(pos, block, radius) -> shape('sphere', pos, [block, radius, null], null), false],
     ['shape sphere <pos> <block> <radius> f <flag>', _(pos, block, radius, flags) -> shape('sphere', pos, [block, radius, null], flags), false],
     ['shape sphere <pos> <block> <radius> <replacement>', _(pos, block, radius, replacement) -> shape('sphere', pos, [block, radius, replacement], null),
@@ -986,6 +995,7 @@ global_lang_keys = global_default_lang = {
     'help_cmd_brush_outline_force'-> 'l Register brush to outline replacing non air too',
     'help_cmd_brush_cube' ->      'l Register brush to create a cube of side length [size] out of [block]',
     'help_cmd_brush_cuboid' ->    'l Register brush to create a cuboid of dimensions [x] [y] and [z] out of [block]',
+    'help_cmd_brush_diamond' ->   'l Register brush to create a diamond with diagonal [size] out of [block]',
     'help_cmd_brush_sphere' ->    'l Register brush to create a sphere of radius [size] out of [block]',
     'help_cmd_brush_ellipsoid' -> 'l Register brush to create a ellipsoid with radii [x_radius], [y_radius] and [z_radius] out of [block]',
     'help_cmd_brush_cylinder' ->  'l Register brush to create a cylinder with [radius] and [height] along [axis] out of [block]',
@@ -1085,6 +1095,7 @@ global_lang_keys = global_default_lang = {
     //Block-setting actions
     'action_cube'->                'cube',
     'action_cuboid' ->             'cuboid',
+    'action_diamond' ->             'diamond',
     'action_ellipsoid' ->          'ellipsoid',
     'action_sphere' ->             'sphere',
     'action_cylinder' ->           'cylinder',
@@ -1186,13 +1197,16 @@ global_brush_reach = 100;
 global_brushes_parameters_map = {
 	'cube'-> ['block', 'size', 'replace'],
 	'cuboid'-> ['block', 'size', 'replace'],
+    'diamond'-> ['block', 'size', 'replace'],
 	'shpere' -> ['block', 'radius', 'replace'],
 	'ellipsoid' -> ['block', 'radii', 'replace'],
 	'cylinder' -> ['block', 'radius', 'height', 'axis', 'replace'],
 	'cone' -> ['block', 'radius', 'height', 'saxis', 'replace'],
     'pyramid' -> ['block', 'radius', 'height', 'saxis', 'replace'],
 	'prism_polygon' -> ['block', 'radius', 'height', 'points', 'axis', 'rotation', 'replace'],
+    'pyramid_polygon' -> ['block', 'radius', 'height', 'points', 'saxis', 'rotation', 'replace'],
 	'prism_star' -> ['block', 'outer_radius', 'inner_radius', 'height', 'points', 'axis', 'rotation', 'replace'],
+    'pyramid_star' -> ['block', 'outer_radius', 'inner_radius', 'height', 'points', 'saxis', 'rotation', 'replace'],
 	'line' -> ['block', 'length', 'replace'],
 	'flood' -> ['block', 'radius', 'axis'],
     'drain' -> ['radius'],
@@ -1356,6 +1370,41 @@ global_brush_shapes={
 
             add_to_history('action_pyramid',player())
         ),
+    'diamond'->_(pos, args, flags)->(
+            [block, size, replacement] = args;
+            flags = _parse_flags(flags);
+
+            half_size = (size+1)/2;
+            c = map(pos, floor(_));
+            offset = half_size%1;
+
+            print([size, half_size, offset, c]);
+
+            loop(half_size,
+                z = _ + offset; print('z = '+_);
+                level = {};
+                hd = half_size - _; //half diagonal on that level
+                loop(hd,
+                    x = _ + offset;
+                    if(flags~'h',
+                        y = hd - x - offset - !bool(offset); print([x, y]);
+                        for(_all_axis_reflections(x, y), level += _ ),
+                    //else, solid
+                        loop(hd - x,
+                            y = _ + offset; print(y);
+                            for(_all_axis_reflections(x, y), level += _ );
+                        )
+                    )
+                );
+
+                for(level, set_block(c + [..._, z], block, replacement, flags, {}));
+                if(z != 0, //don't place the middle slice twice
+                    for(level, set_block(c + [..._, -z], block, replacement, flags, {}));
+                )
+            );
+            add_to_history('action_diamond',player())
+        ),
+
     'cylinder'->_(pos, args, flags)->(
             [block, radius, height, axis, replacement] = args;
 
@@ -1693,7 +1742,7 @@ _pyramid_generic(pos, args, flags) -> (
     point = if(slice(signed_axis, 0, 1)=='+', 1, -1);
     offset = offset * point;
 
-    base = center - offset * (height+1)/2;
+    base = center;
     hollow = flags~'h';
 
     previous = {};
@@ -1803,14 +1852,17 @@ _make_square(sidelength, inner, axis, center) -> (
     [perimeter, interior]
 );
 
-_all_reflections(x, y) -> ( 
+_all_reflections(x, y) -> [ 
     //this takes in a point in the first quarter plane under the x=y line and reflects it about
     //that line, and reflects the resulting pair of points about all axes, resulting in 8 points
-    [
-        [x,y], [x,-y], [-x,y], [-x,-y],
-        [y,x], [y,-x], [-y,x], [-y,-x]
-    ]
-);
+    [x,y], [x,-y], [-x,y], [-x,-y],
+    [y,x], [y,-x], [-y,x], [-y,-x]
+];
+
+_all_axis_reflections(x, y) -> [
+    //this takes in a point and returns all possible reflections about the two axes
+    [x,y], [x,-y], [-x,y], [-x,-y]
+];
 
 fill_flat_circle(pos, offset, dr, orientation, block, hollow, replacement, flags)->(
     r = floor(dr);

--- a/se.sc
+++ b/se.sc
@@ -182,6 +182,7 @@ base_commands_map = [
     ['brush line <block> <length> <replacement> f <flag>', _(block, length, replacement, flags) -> brush('line', flags, block, length, replacement), false],
     ['brush paste ', _() -> brush('paste_brush', null), [-1, 'help_cmd_brush_paste', 'help_cmd_brush_generic', null]],
     ['brush paste f <flag>',  _(flags) -> brush('paste_brush', flags), false],
+    
     ['brush prism_polygon <block> <radius> <height> <points>', 
         _(block, radius, height, n_points) -> brush('prism_polygon', null, block, radius, height, n_points, 'y', 0, null), false],
     ['brush prism_polygon <block> <radius> <height> <points> f <flag>',
@@ -199,23 +200,41 @@ base_commands_map = [
        [4, 'help_cmd_brush_polygon', 'help_cmd_brush_generic', null]],
     ['brush prism_polygon <block> <radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
        _(block, radius, height, n_points, axis, rotation, replacement, flags) -> brush('prism_polygon', flags, block, radius, height, n_points, axis, rotation, replacement), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points>',
-        _(block, outer_radius, inner_radius, height, n_points) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, 'y', 0, null), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
-       _(block, outer_radius, inner_radius, height, n_points, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, 'y', 0, null), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> <axis>',
-       _(block, outer_radius, inner_radius, height, n_points, axis) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, axis, 0, null), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> <axis> f <flag>',
-       _(block, outer_radius, inner_radius, height, n_points, axis, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, axis, 0, null), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees>',
-       _(block, outer_radius, inner_radius, height, n_points, axis, rotation) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, axis, rotation, null), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> f <flag>',
-       _(block, outer_radius, inner_radius, height, n_points, axis, rotation, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, axis, rotation, null), false],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement>',
-       _(block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement), 
-       [5, 'help_cmd_brush_star', 'help_cmd_brush_generic', null]],
-    ['brush prism_star <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
-       _(block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement), false],
+
+    ['brush piramid_polygon <block> <radius> <height> <points> f <flag>',
+       _(block, radius, height, n_points, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, '+y', 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis>', 
+       _(block, radius, height, n_points, saxis) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> f <flag>',
+       _(block, radius, height, n_points, saxis, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees>',
+       _(block, radius, height, n_points, saxis, rotation) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(block, radius, height, n_points, saxis, rotation, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(block, radius, height, n_points, saxis, rotation, replacement) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, replacement), 
+       [4, 'help_cmd_brush_polygon_pyramid', 'help_cmd_brush_generic', null]],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(block, radius, height, n_points, saxis, rotation, replacement, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, replacement), false],
+    
+    ['brush piramid_polygon <block> <radius> <height> <points>', 
+        _(block, radius, height, n_points) -> brush('piramid_polygon', null, block, radius, height, n_points, '+y', 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> f <flag>',
+       _(block, radius, height, n_points, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, '+y', 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis>', 
+       _(block, radius, height, n_points, saxis) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> f <flag>',
+       _(block, radius, height, n_points, saxis, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, 0, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees>',
+       _(block, radius, height, n_points, saxis, rotation) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(block, radius, height, n_points, saxis, rotation, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, null), false],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(block, radius, height, n_points, saxis, rotation, replacement) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, replacement), 
+       [4, 'help_cmd_brush_star', 'help_cmd_brush_generic', null]],
+    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(block, radius, height, n_points, saxis, rotation, replacement, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, replacement), false],
+
     ['brush feature <feature> ', _(feature) -> brush('feature', null, feature), [-1, 'help_cmd_brush_feature', 'help_cmd_brush_generic', null]],
     ['brush drain', _()->brush('drain', null, 30), false],
 	['brush drain <radius>', _(radius)->brush('drain', null, radius), [0, 'help_cmd_brush_drain', 'help_cmd_brush_generic', null]],
@@ -277,6 +296,7 @@ base_commands_map = [
     ['shape pyramid <pos> <block> <side_size> <height> <saxis> f <flag>', _(pos, block, radius, height, axis, flags) -> shape('pyramid', pos, [block, radius, height, axis, null], flags), false],
     ['shape pyramid <pos> <block> <side_size> <height> <saxis> <replacement>', _(pos, block, radius, height, axis, replacement) -> shape('pyramid', pos, [block, radius, height, axis, replacement], null),
         [2, 'help_cmd_brush_cone', 'help_cmd_brush_generic', null]],
+    
     ['shape prism_polygon <pos> <block> <radius> <height> <points>',
         _(pos, block, radius, height, n_points) -> shape('prism_polygon', pos, [block, radius, height, n_points, 'y', 0, null], null), false],
     ['shape prism_polygon <pos> <block> <radius> <height> <points> f <flag>',
@@ -294,6 +314,25 @@ base_commands_map = [
        [4, 'help_cmd_brush_polygon', 'help_cmd_brush_generic', null]],
     ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
        _(pos, block, radius, height, n_points, axis, rotation, replacement, flags) -> shape('prism_polygon', pos, [block, radius, height, n_points, axis, rotation, replacement], flags), false],
+        
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points>',
+        _(pos, block, radius, height, n_points) -> shape('piramid_polygon', pos, [block, radius, height, n_points, '+y', 0, null], null), false],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> f <flag>',
+       _(pos, block, radius, height, n_points, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, '+y', 0, null], flags), false],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis>',
+       _(pos, block, radius, height, n_points, saxis) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, 0, null], null), false],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> f <flag>',
+       _(pos, block, radius, height, n_points, saxis, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, 0, null], flags), false],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees>',
+       _(pos, block, radius, height, n_points, saxis, rotation) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, null], null), false],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(pos, block, radius, height, n_points, saxis, rotation, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, null], flags), false],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(pos, block, radius, height, n_points, saxis, rotation, replacement) ->shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, replacement], null),
+       [4, 'help_cmd_brush_polygon_pyramid', 'help_cmd_brush_generic', null]],
+    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(pos, block, radius, height, n_points, saxis, rotation, replacement, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, replacement], flags), false],
+
     ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points>',
         _(pos, block, outer_radius, inner_radius, height, n_points) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, 'y', 0, null], null), false],
     ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
@@ -308,7 +347,7 @@ base_commands_map = [
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation, flags) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, null], flags), false],
     ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement) ->shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement], null),
-       [4, 'help_cmd_brush_polygon', 'help_cmd_brush_generic', null]],
+       [4, 'help_cmd_brush_star', 'help_cmd_brush_generic', null]],
     ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement, flags) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement], flags), false],
 
@@ -366,7 +405,7 @@ __config()->{
     'arguments'->{
         'replacement'->{'type'->'blockpredicate'},
         'moves'->{'type'->'int','min'->1,'suggest'->[1]},//todo decide on whether or not to add max undo limit
-        'degrees'->{'type'->'int','suggest'->[0,90]},
+        'degrees'->{'type'->'float','suggest'->[0,90]},
         'axis'->{'type'->'term','options'->['x','y','z']},
         'saxis'->{'type'->'term', 'options'->['+x', '-x', '+y', '-y', '+z', '-z']},
         'sides'->{'type'->'term', 'options'->['x', 'y', 'z', 'xy', 'xz', 'yz', 'xyz']},
@@ -914,6 +953,7 @@ global_lang_keys = global_default_lang = {
     'help_cmd_brush_cone' ->      'l Register brush to create a cone with [radius] and [height] along [axis] in the direciton given by the sign',
     'help_cmd_brush_pyramid' ->   'l Register brush to create a pyramid with [radius] and [height] along [axis] in the direciton given by the sign',
     'help_cmd_brush_polygon' ->   'l Register brush to create a polygon prism with [points] ammount of sides',
+    'help_cmd_brush_polygon' ->   'l Register brush to create a polygon pyramid with [points] ammount of sides',
     'help_cmd_brush_star' ->      'l Register brush to create a star prism with [points] ammount of points',
     'help_cmd_brush_line' ->      'l Register brush to create a line from player to where you click of [length], if given',
     'help_cmd_brush_flood' ->     'l Register brush to perform flood fill out of [block] starting on right clicked block',
@@ -974,6 +1014,7 @@ global_lang_keys = global_default_lang = {
     'brush_new' ->			'w Registerd new %s brush to %s', //item, action
     'brush_list_header' ->              'bc === Current brushes are ===',
     'brush_extra_info' ->               'ig For detailed info on a brush click the [i] icon',
+    'brush_empty_list' ->               'ig You don\'t have any brushes registered',
     'brush_new_reach' ->                'w Brush reach was set to %d blocks',
     'brush_reach' ->                    'w Brush reach is currently %d blocks', // reach
 	'no_brush_error'->					'r %s in not a brush', //item
@@ -1112,7 +1153,7 @@ global_brushes_parameters_map = {
 	'line' -> ['block', 'length', 'replace'],
 	'flood' -> ['block', 'radius', 'axis'],
     'drain' -> ['radius'],
-    'hollow' -> ['block'],
+    'hollow' -> ['radius'],
     'outline'-> ['block', 'outline block', 'force'],
 	'feature' -> ['what'],
 	'spray' -> ['block', 'size', 'count', 'replace'],
@@ -1188,7 +1229,6 @@ shape(action, pos, args, flags)->
 
 _brush_action(pos, brush) -> (
     [action, args, flags] = global_brushes:brush;
-    if(action == 'feature', print(player(), format('d Beware, placing features is very experimental and doesn\'t have support for the undo function')));
     shape(action,pos, args, flags)
 );
 
@@ -1224,7 +1264,7 @@ global_brush_shapes={
     'cone'->_(pos, args, flags)->(
             [block, radius, height, signed_axis, replacement] = args;
             roh = radius / height; //radius over height
-            _shape_maker(h, hollow, axis, base, outer(radius), outer(roh), outer(height)) -> (
+            _shape_maker(h, hollow, axis, base, previous, outer(radius), outer(roh), outer(height)) -> (
                 r = radius - roh*h;
                 inner = if(
                     !hollow, //only use discs
@@ -1234,7 +1274,7 @@ global_brush_shapes={
                     //else
                         r-1
                 );
-                if(r<=0.5,
+                if(r<=1,
                     [[base], [base]],
                     _make_circle(r, inner, axis, base);
                 );
@@ -1246,7 +1286,7 @@ global_brush_shapes={
     'pyramid'->_(pos, args, flags)->(
             [block, sidelength, height, signed_axis, replacement] = args;
             roh = sidelength / height; //radius over height
-            _shape_maker(h, hollow, axis, base, outer(sidelength), outer(roh), outer(height)) -> (
+            _shape_maker(h, hollow, axis, base, previous, outer(sidelength), outer(roh), outer(height)) -> (
                 r = sidelength - roh*h;
                 inner = if(
                     !hollow, //only use discs
@@ -1382,7 +1422,6 @@ global_brush_shapes={
                             visited += cn_pos;
                             queue += cn_pos
                         );
-                        print([current_neighbour, cf]);
                     )
                 );
             );
@@ -1391,16 +1430,20 @@ global_brush_shapes={
             add_to_history('action_outline', player())
         ),
 
+
     'prism_polygon'->_(pos, args, flags)->(
             [block, radius, height, n_points, axis, rotation, replacement] = args;
             center = map(pos, floor(_));
             flags = _parse_flags(flags);
+
             // get points on the circle that inscribes the shape
             points = _get_circle_points(radius, n_points, rotation);
             points:length(points) = points:0; // add first point at the end to close curve
+
             // get points and draw the connecting lines
             perimeter = _connect_with_lines(points, center, axis);
-            interior = _flood_fill_shape(perimeter, center, axis);
+            interior = _flood_fill_shape(perimeter, center, axis, {});
+
             offset = _get_prism_offset(height, axis);
             if(flags~'h',
                 for(perimeter, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {}) ));
@@ -1410,6 +1453,38 @@ global_brush_shapes={
                 ),
                 for(interior, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {})))
             );
+            add_to_history('action_prism_polygon',player());
+        ),
+
+    'piramid_polygon'->_(pos, args, flags)->(
+            [block, radius, height, n_points, signed_axis, rotation, replacement] = args;
+            
+            roh = radius / height; //radius over height
+            _shape_maker(h, hollow, axis, base, previous, outer(radius), outer(roh), outer(n_points), outer(rotation)) -> (
+                r = radius - roh*h;
+                // get points on the circle that inscribes the shape
+                if(r>1,
+                    points = _get_circle_points(r, n_points, rotation);
+                    points:length(points) = points:0; // add first point at the end to close curve
+
+                    // get points and draw the connecting lines
+                    perimeter = _connect_with_lines(points, base, axis);
+                    interior = _flood_fill_shape(perimeter, base, axis, {});
+                    if(hollow && h!=0,
+                        perimeter = _flood_fill_shape(perimeter, base, axis, previous);
+                    ),
+                //else
+                    perimeter = {base->null};
+                    interior =  {base->null};
+                );
+                [perimeter, interior]
+            );
+            newargs = [block, radius, height, signed_axis, replacement];
+            _pyramid_generic(pos, newargs, flags);   
+
+            flags = _parse_flags(flags);
+            if(flags~'h', print(player(), format('d Hollow polygon pyramids are experimental. Use solid pyramids and a hollow brush if you encounter issues.')));
+
             add_to_history('action_prism_polygon',player())
         ),
 
@@ -1424,7 +1499,7 @@ global_brush_shapes={
             interlaced_list += inner_points:0; // add first point at the end to close curve
             // get points and draw the connecting lines
             perimeter = _connect_with_lines(interlaced_list, center, axis);
-            interior = _flood_fill_shape(perimeter, center, axis);
+            interior = _flood_fill_shape(perimeter, center, axis, {});
             offset = _get_prism_offset(height, axis);
             if(flags~'h',
                 for(perimeter, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {}) ));
@@ -1531,14 +1606,18 @@ _pyramid_generic(pos, args, flags) -> (
     base = center - offset * (height+1)/2;
     hollow = flags~'h';
 
+    previous = {};
     loop(height,
-        h = _;
-        [perimeter, interior] = _shape_maker(h, hollow, axis, base);
+        h = height - 1 -_;
+        [perimeter, interior] = _shape_maker(h, hollow, axis, base, previous);
+
         if(h==0 || !hollow, 
-            for(interior, set_block(_+offset*h, block, replacement, flags, {})),  //closed bottom
-            for(perimeter, set_block(_+offset*h, block, replacement, flags, {}));
+            for(interior, set_block(_+offset*h;, block, replacement, flags, {})),  //closed bottom
+            for(perimeter, set_block(_+offset*h;, block, replacement, flags, {}))
         );
         if(h==height-1, set_block(base + offset*(h), block, replacement, flags, {})); //manually place point
+
+        previous = interior;
     );
 );
 
@@ -1710,7 +1789,7 @@ _interlace_lists(l1, l2) -> (
     out = [];
     for(l1,
         out:length(out) = _;
-        out:length(out) =  l2:_i;
+        out:length(out) = l2:_i;
     );
     return(out);
 );
@@ -1725,9 +1804,10 @@ _get_prism_offset(height, axis) -> (
     )
 );
 
-_flood_fill_shape(perimeter, center, axis) ->(
+_flood_fill_shape(perimeter, center, axis, exclude) ->(
     // returns blocks corresponding to the interior of the shape defined by <perimeter>
     // should work in 3D too giving a close surphase and passing null as <axis>
+    
     max_iter = global_max_iter;
     if(
         axis==null, flood_neighbours(block) -> map(neighbours(block), pos(_)); max_iter = global_max_iter^(2/3),
@@ -1736,9 +1816,16 @@ _flood_fill_shape(perimeter, center, axis) ->(
         axis=='z', flood_neighbours(block) -> [pos_offset(block, 'east'), pos_offset(block, 'west'), pos_offset(block, 'up'), pos_offset(block, 'down')]
     );
 
+    center = map(center, floor(_));
+    interior = {};
 
-    interior = {center->null};
-    map(perimeter,interior:_ = null);
+    map(perimeter, interior:_ = null);
+    if(has(interior, center),
+        // exit early if the shape is too small
+        return(interior),
+        //else, add the center and start
+        if(!has(exclude, center), interior += center);
+    );
     queue = [center];
 
     while(length(queue)>0, max_iter,
@@ -1749,9 +1836,9 @@ _flood_fill_shape(perimeter, center, axis) ->(
         for(flood_neighbours(current_pos),
             current_neighbour = _;
             // check neighbours, add the non visited ones to the visited set
-            if(!has(interior, current_neighbour),
-                interior:current_neighbour = null;
-                queue:length(queue) = current_neighbour;
+            if(!has(exclude, current_neighbour) && !has(interior, current_neighbour),
+                interior += current_neighbour;
+                queue += current_neighbour;
             );
         );
     );

--- a/se.sc
+++ b/se.sc
@@ -183,59 +183,79 @@ base_commands_map = [
     ['brush line <block> <length> <replacement> f <flag>', _(block, length, replacement, flags) -> brush('line', flags, block, length, replacement), false],
     ['brush paste ', _() -> brush('paste_brush', null), [-1, 'help_cmd_brush_paste', 'help_cmd_brush_generic', null]],
     ['brush paste f <flag>',  _(flags) -> brush('paste_brush', flags), false],
-    
-    ['brush prism_polygon <block> <radius> <height> <points>', 
+        
+    ['brush polygon prism <block> <radius> <height> <points>', 
         _(block, radius, height, n_points) -> brush('prism_polygon', null, block, radius, height, n_points, 'y', 0, null), false],
-    ['brush prism_polygon <block> <radius> <height> <points> f <flag>',
+    ['brush polygon prism <block> <radius> <height> <points> f <flag>',
        _(block, radius, height, n_points, flags) -> brush('prism_polygon', flags, block, radius, height, n_points, 'y', 0, null), false],
-    ['brush prism_polygon <block> <radius> <height> <points> <axis>', 
+    ['brush polygon prism <block> <radius> <height> <points> <axis>', 
        _(block, radius, height, n_points, axis) -> brush('prism_polygon', null, block, radius, height, n_points, axis, 0, null), false],
-    ['brush prism_polygon <block> <radius> <height> <points> <axis> f <flag>',
+    ['brush polygon prism <block> <radius> <height> <points> <axis> f <flag>',
        _(block, radius, height, n_points, axis, flags) -> brush('prism_polygon', flags, block, radius, height, n_points, axis, 0, null), false],
-    ['brush prism_polygon <block> <radius> <height> <points> <axis> <degrees>',
+    ['brush polygon prism <block> <radius> <height> <points> <axis> <degrees>',
        _(block, radius, height, n_points, axis, rotation) -> brush('prism_polygon', null, block, radius, height, n_points, axis, rotation, null), false],
-    ['brush prism_polygon <block> <radius> <height> <points> <axis> <degrees> f <flag>',
+    ['brush polygon prism <block> <radius> <height> <points> <axis> <degrees> f <flag>',
        _(block, radius, height, n_points, axis, rotation, flags) -> brush('prism_polygon', flags, block, radius, height, n_points, axis, rotation, null), false],
-    ['brush prism_polygon <block> <radius> <height> <points> <axis> <degrees> <replacement>',
+    ['brush polygon prism <block> <radius> <height> <points> <axis> <degrees> <replacement>',
        _(block, radius, height, n_points, axis, rotation, replacement) -> brush('prism_polygon', null, block, radius, height, n_points, axis, rotation, replacement), 
        [4, 'help_cmd_brush_polygon', 'help_cmd_brush_generic', null]],
-    ['brush prism_polygon <block> <radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
+    ['brush polygon prism <block> <radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
        _(block, radius, height, n_points, axis, rotation, replacement, flags) -> brush('prism_polygon', flags, block, radius, height, n_points, axis, rotation, replacement), false],
 
-    ['brush piramid_polygon <block> <radius> <height> <points> f <flag>',
-       _(block, radius, height, n_points, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, '+y', 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis>', 
-       _(block, radius, height, n_points, saxis) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> f <flag>',
-       _(block, radius, height, n_points, saxis, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees>',
-       _(block, radius, height, n_points, saxis, rotation) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
-       _(block, radius, height, n_points, saxis, rotation, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
-       _(block, radius, height, n_points, saxis, rotation, replacement) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, replacement), 
+    ['brush polygon pyramid <block> <radius> <height> <points>',
+       _(block, radius, height, n_points) -> brush('pyramid_polygon', null, block, radius, height, n_points, '+y', 0, null), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> f <flag>',
+       _(block, radius, height, n_points, flags) -> brush('pyramid_polygon', flags, block, radius, height, n_points, '+y', 0, null), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> <saxis>', 
+       _(block, radius, height, n_points, saxis) -> brush('pyramid_polygon', null, block, radius, height, n_points, saxis, 0, null), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> <saxis> f <flag>',
+       _(block, radius, height, n_points, saxis, flags) -> brush('pyramid_polygon', flags, block, radius, height, n_points, saxis, 0, null), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> <saxis> <degrees>',
+       _(block, radius, height, n_points, saxis, rotation) -> brush('pyramid_polygon', null, block, radius, height, n_points, saxis, rotation, null), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(block, radius, height, n_points, saxis, rotation, flags) -> brush('pyramid_polygon', flags, block, radius, height, n_points, saxis, rotation, null), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(block, radius, height, n_points, saxis, rotation, replacement) -> brush('pyramid_polygon', null, block, radius, height, n_points, saxis, rotation, replacement), 
        [4, 'help_cmd_brush_polygon_pyramid', 'help_cmd_brush_generic', null]],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
-       _(block, radius, height, n_points, saxis, rotation, replacement, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, replacement), false],
+    ['brush polygon pyramid <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(block, radius, height, n_points, saxis, rotation, replacement, flags) -> brush('pyramid_polygon', flags, block, radius, height, n_points, saxis, rotation, replacement), false],
+        
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points>',
+        _(block, outer_radius, inner_radius, height, n_points) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, 'y', 0, null), false],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, 'y', 0, null), false],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> <axis>',
+       _(block, outer_radius, inner_radius, height, n_points, axis) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, axis, 0, null), false],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> <axis> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, axis, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, axis, 0, null), false],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees>',
+       _(block, outer_radius, inner_radius, height, n_points, axis, rotation) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, axis, rotation, null), false],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, axis, rotation, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, axis, rotation, null), false],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement>',
+       _(block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement) -> brush('prism_star', null, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement), 
+       [5, 'help_cmd_brush_star', 'help_cmd_brush_generic', null]],
+    ['brush star prism <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement, flags) -> brush('prism_star', flags, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement), false],
     
-    ['brush piramid_polygon <block> <radius> <height> <points>', 
-        _(block, radius, height, n_points) -> brush('piramid_polygon', null, block, radius, height, n_points, '+y', 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> f <flag>',
-       _(block, radius, height, n_points, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, '+y', 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis>', 
-       _(block, radius, height, n_points, saxis) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> f <flag>',
-       _(block, radius, height, n_points, saxis, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, 0, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees>',
-       _(block, radius, height, n_points, saxis, rotation) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
-       _(block, radius, height, n_points, saxis, rotation, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, null), false],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
-       _(block, radius, height, n_points, saxis, rotation, replacement) -> brush('piramid_polygon', null, block, radius, height, n_points, saxis, rotation, replacement), 
-       [4, 'help_cmd_brush_star', 'help_cmd_brush_generic', null]],
-    ['brush piramid_polygon <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
-       _(block, radius, height, n_points, saxis, rotation, replacement, flags) -> brush('piramid_polygon', flags, block, radius, height, n_points, saxis, rotation, replacement), false],
-
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points>',
+        _(block, outer_radius, inner_radius, height, n_points) -> brush('pyramid_star', null, block, outer_radius, inner_radius, height, n_points, '+y', 0, null), false],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, flags) -> brush('pyramid_star', flags, block, outer_radius, inner_radius, height, n_points, '+y', 0, null), false],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> <saxis>',
+       _(block, outer_radius, inner_radius, height, n_points, saxis) -> brush('pyramid_star', null, block, outer_radius, inner_radius, height, n_points, saxis, 0, null), false],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> <saxis> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, saxis, flags) -> brush('pyramid_star', flags, block, outer_radius, inner_radius, height, n_points, saxis, 0, null), false],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees>',
+       _(block, outer_radius, inner_radius, height, n_points, saxis, rotation) -> brush('pyramid_star', null, block, outer_radius, inner_radius, height, n_points, saxis, rotation, null), false],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, saxis, rotation, flags) -> brush('pyramid_star', flags, block, outer_radius, inner_radius, height, n_points, saxis, rotation, null), false],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement) -> brush('pyramid_star', null, block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement), 
+       [5, 'help_cmd_brush_star_pyramid', 'help_cmd_brush_generic', null]],
+    ['brush star pyramid <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement, flags) -> brush('pyramid_star', flags, block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement), false],
+   
     ['brush feature <feature> ', _(feature) -> brush('feature', null, feature), [-1, 'help_cmd_brush_feature', 'help_cmd_brush_generic', null]],
     ['brush drain', _()->brush('drain', null, 30), false],
 	['brush drain <radius>', _(radius)->brush('drain', null, radius), [0, 'help_cmd_brush_drain', 'help_cmd_brush_generic', null]],
@@ -298,60 +318,78 @@ base_commands_map = [
     ['shape pyramid <pos> <block> <side_size> <height> <saxis> <replacement>', _(pos, block, radius, height, axis, replacement) -> shape('pyramid', pos, [block, radius, height, axis, replacement], null),
         [2, 'help_cmd_brush_cone', 'help_cmd_brush_generic', null]],
     
-    ['shape prism_polygon <pos> <block> <radius> <height> <points>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points>',
         _(pos, block, radius, height, n_points) -> shape('prism_polygon', pos, [block, radius, height, n_points, 'y', 0, null], null), false],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> f <flag>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> f <flag>',
        _(pos, block, radius, height, n_points, flags) -> shape('prism_polygon', pos, [block, radius, height, n_points, 'y', 0, null], flags), false],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> <axis>',
        _(pos, block, radius, height, n_points, axis) -> shape('prism_polygon', pos, [block, radius, height, n_points, axis, 0, null], null), false],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis> f <flag>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> <axis> f <flag>',
        _(pos, block, radius, height, n_points, axis, flags) -> shape('prism_polygon', pos, [block, radius, height, n_points, axis, 0, null], flags), false],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis> <degrees>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> <axis> <degrees>',
        _(pos, block, radius, height, n_points, axis, rotation) -> shape('prism_polygon', pos, [block, radius, height, n_points, axis, rotation, null], null), false],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis> <degrees> f <flag>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> <axis> <degrees> f <flag>',
        _(pos, block, radius, height, n_points, axis, rotation, flags) -> shape('prism_polygon', pos, [block, radius, height, n_points, axis, rotation, null], flags), false],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis> <degrees> <replacement>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> <axis> <degrees> <replacement>',
        _(pos, block, radius, height, n_points, axis, rotation, replacement) ->shape('prism_polygon', pos, [block, radius, height, n_points, axis, rotation, replacement], null),
        [4, 'help_cmd_brush_polygon', 'help_cmd_brush_generic', null]],
-    ['shape prism_polygon <pos> <block> <radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
+    ['shape polygon prism <pos> <block> <radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
        _(pos, block, radius, height, n_points, axis, rotation, replacement, flags) -> shape('prism_polygon', pos, [block, radius, height, n_points, axis, rotation, replacement], flags), false],
         
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points>',
-        _(pos, block, radius, height, n_points) -> shape('piramid_polygon', pos, [block, radius, height, n_points, '+y', 0, null], null), false],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> f <flag>',
-       _(pos, block, radius, height, n_points, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, '+y', 0, null], flags), false],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis>',
-       _(pos, block, radius, height, n_points, saxis) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, 0, null], null), false],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> f <flag>',
-       _(pos, block, radius, height, n_points, saxis, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, 0, null], flags), false],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees>',
-       _(pos, block, radius, height, n_points, saxis, rotation) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, null], null), false],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
-       _(pos, block, radius, height, n_points, saxis, rotation, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, null], flags), false],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
-       _(pos, block, radius, height, n_points, saxis, rotation, replacement) ->shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, replacement], null),
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points>',
+        _(pos, block, radius, height, n_points) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, '+y', 0, null], null), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> f <flag>',
+       _(pos, block, radius, height, n_points, flags) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, '+y', 0, null], flags), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> <saxis>',
+       _(pos, block, radius, height, n_points, saxis) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, saxis, 0, null], null), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> <saxis> f <flag>',
+       _(pos, block, radius, height, n_points, saxis, flags) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, saxis, 0, null], flags), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> <saxis> <degrees>',
+       _(pos, block, radius, height, n_points, saxis, rotation) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, null], null), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(pos, block, radius, height, n_points, saxis, rotation, flags) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, null], flags), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(pos, block, radius, height, n_points, saxis, rotation, replacement) ->shape('pyramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, replacement], null),
        [4, 'help_cmd_brush_polygon_pyramid', 'help_cmd_brush_generic', null]],
-    ['shape piramid_polygon <pos> <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
-       _(pos, block, radius, height, n_points, saxis, rotation, replacement, flags) -> shape('piramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, replacement], flags), false],
+    ['shape polygon pyramid <pos> <block> <radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(pos, block, radius, height, n_points, saxis, rotation, replacement, flags) -> shape('pyramid_polygon', pos, [block, radius, height, n_points, saxis, rotation, replacement], flags), false],
 
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points>',
         _(pos, block, outer_radius, inner_radius, height, n_points) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, 'y', 0, null], null), false],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
        _(pos, block, outer_radius, inner_radius, height, n_points, flags) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, 'y', 0, null], flags), false],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, 0, null], null), false],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> f <flag>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> f <flag>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, flags) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, 0, null], flags), false],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, null], null), false],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> f <flag>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> f <flag>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation, flags) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, null], flags), false],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement) ->shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement], null),
        [4, 'help_cmd_brush_star', 'help_cmd_brush_generic', null]],
-    ['shape prism_star <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
+    ['shape star prism <pos> <block> <outer_radius> <inner_radius> <height> <points> <axis> <degrees> <replacement> f <flag>',
        _(pos, block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement, flags) -> shape('prism_star', pos, [block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement], flags), false],
 
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points>',
+        _(pos, block, outer_radius, inner_radius, height, n_points) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, '+y', 0, null], null), false],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> f <flag>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, flags) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, '+y', 0, null], flags), false],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> <saxis>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, saxis) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, saxis, 0, null], null), false],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> <saxis> f <flag>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, saxis, flags) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, saxis, 0, null], flags), false],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, saxis, rotation) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, saxis, rotation, null], null), false],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees> f <flag>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, saxis, rotation, flags) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, saxis, rotation, null], flags), false],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees> <replacement>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement) ->shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement], null),
+       [4, 'help_cmd_brush_star_pyramid', 'help_cmd_brush_generic', null]],
+    ['shape star pyramid <pos> <block> <outer_radius> <inner_radius> <height> <points> <saxis> <degrees> <replacement> f <flag>',
+       _(pos, block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement, flags) -> shape('pyramid_star', pos, [block, outer_radius, inner_radius, height, n_points, saxis, rotation, replacement], flags), false],
+        
     // we need a better way of changing 'settings'
     ['settings quick_select <bool>', _(b) -> global_quick_select = b, false],
     ['settings max_iterations <int>', _(int) -> global_max_iter = i, false],
@@ -952,10 +990,11 @@ global_lang_keys = global_default_lang = {
     'help_cmd_brush_ellipsoid' -> 'l Register brush to create a ellipsoid with radii [x_radius], [y_radius] and [z_radius] out of [block]',
     'help_cmd_brush_cylinder' ->  'l Register brush to create a cylinder with [radius] and [height] along [axis] out of [block]',
     'help_cmd_brush_cone' ->      'l Register brush to create a cone with [radius] and [height] along [axis] in the direciton given by the sign',
-    'help_cmd_brush_pyramid' ->   'l Register brush to create a pyramid with [radius] and [height] along [axis] in the direciton given by the sign',
+    'help_cmd_brush_pyramid' ->   'l Register brush to create a pyramid with [side_size] and [height] along [axis] in the direciton given by the sign',
     'help_cmd_brush_polygon' ->   'l Register brush to create a polygon prism with [points] ammount of sides',
-    'help_cmd_brush_polygon' ->   'l Register brush to create a polygon pyramid with [points] ammount of sides',
+    'help_cmd_brush_polygon_pyramid' -> 'l Register brush to create a polygon pyramid with [points] ammount of sides',
     'help_cmd_brush_star' ->      'l Register brush to create a star prism with [points] ammount of points',
+    'help_cmd_brush_star_pyramid' -> 'l Register brush to create a star pyramid with [points] ammount of points',
     'help_cmd_brush_line' ->      'l Register brush to create a line from player to where you click of [length], if given',
     'help_cmd_brush_flood' ->     'l Register brush to perform flood fill out of [block] starting on right clicked block',
     'help_cmd_brush_paste' ->     'l Register brush to paste current clipboard with origin on targeted block',
@@ -1053,7 +1092,9 @@ global_lang_keys = global_default_lang = {
     'action_pyramid' ->            'pyramid',
     'action_line' ->               'line',
     'action_prism_polygon' ->      'polygon prism',
+    'action_pyramid_polygon' ->    'polygon pyramid',
     'action_prism_star' ->         'star prism',
+    'action_pyramid_star' ->       'star pyramid',
     'action_structure_paste' ->    'structure paste',
     'action_set' ->                'set',
     'action_flood' ->              'flood',
@@ -1466,7 +1507,7 @@ global_brush_shapes={
             add_to_history('action_prism_polygon',player());
         ),
 
-    'piramid_polygon'->_(pos, args, flags)->(
+    'pyramid_polygon'->_(pos, args, flags)->(
             [block, radius, height, n_points, signed_axis, rotation, replacement] = args;
             
             roh = radius / height; //radius over height
@@ -1495,18 +1536,20 @@ global_brush_shapes={
             flags = _parse_flags(flags);
             if(flags~'h', print(player(), format('d Hollow polygon pyramids are experimental. Use solid pyramids and a hollow brush if you encounter issues.')));
 
-            add_to_history('action_prism_polygon',player())
+            add_to_history('action_pyramid_polygon',player())
         ),
 
     'prism_star'->_(pos, args, flags)->(
             [block, outer_radius, inner_radius, height, n_points, axis, rotation, replacement] = args;
             center = map(pos, floor(_));
             flags = _parse_flags(flags);
+
             // get points in inner and pouter radius + interlace them
-            inner_points = _get_circle_points(inner_radius, n_points, phase);
-            outer_points = _get_circle_points(outer_radius, n_points, phase + 360/n_points/2);
+            inner_points = _get_circle_points(inner_radius, n_points, rotation);
+            outer_points = _get_circle_points(outer_radius, n_points, rotation + 360/n_points/2);
             interlaced_list = _interlace_lists(inner_points, outer_points);
             interlaced_list += inner_points:0; // add first point at the end to close curve
+
             // get points and draw the connecting lines
             perimeter = _connect_with_lines(interlaced_list, center, axis);
             interior = _flood_fill_shape(perimeter, center, axis, {});
@@ -1520,6 +1563,43 @@ global_brush_shapes={
                 for(interior, volume(_+offset, _-offset, set_block(_, block, replacement, flags, {})))
             );
             add_to_history('action_prism_polygon',player())
+        ),
+
+    'pyramid_star'->_(pos, args, flags)->(
+            [block, outer_radius, inner_radius, height, n_points, signed_axis, rotation, replacement] = args;
+            
+            oroh = outer_radius / height; //outer radius over height
+            iroh = inner_radius / height; //inner radius over height
+            _shape_maker(h, hollow, axis, base, previous, outer(outer_radius), outer(inner_radius), outer(oroh), outer(iroh), outer(n_points), outer(rotation)) -> (
+                or = outer_radius - oroh*h;
+                ir = inner_radius - iroh*h;
+                
+                // get points on the circle that inscribes the shape
+                if(ir>1,
+                    inner_points = _get_circle_points(ir, n_points, rotation);
+                    outer_points = _get_circle_points(or, n_points, rotation + 360/n_points/2);
+                    interlaced_list = _interlace_lists(inner_points, outer_points);
+                    interlaced_list += inner_points:0; // add first point at the end to close curve
+                    
+                    // get points and draw the connecting lines
+                    perimeter = _connect_with_lines(interlaced_list, base, axis);
+                    interior = _flood_fill_shape(perimeter, base, axis, {});
+                    if(hollow && h!=0,
+                        perimeter = _flood_fill_shape(perimeter, base, axis, previous);
+                    ),
+                //else
+                    perimeter = {base->null};
+                    interior =  {base->null};
+                );
+                [perimeter, interior]
+            );
+            newargs = [block, radius, height, signed_axis, replacement];
+            _pyramid_generic(pos, newargs, flags);   
+
+            flags = _parse_flags(flags);
+            if(flags~'h', print(player(), format('d Hollow star pyramids are experimental. Use solid pyramids and a hollow brush if you encounter issues.')));
+
+            add_to_history('action_pyramid_star',player())
         ),
 
     'spray'->_(pos, args, flags)->(


### PR DESCRIPTION
I re-introduced the old shapes implementations to ahve a version to ship with the next release until #94 is done. Also:
* improved on the efficiency of **cones** and **cylinders**, which were awful (they used to check _every block_ in the cuboid that inscribed them) and are now pretty decent. Only improvement that could be done is finding a better circle algorithm.
* **shpere** and **ellipsoid** still do the awfull "check every block" thing, thos need fixing.
* added working **pyramid** implementation off of the cone code, making hollow pyramids work was not trivial
* since I had a "pyramid with arbitrary base" thing going, I added **polygon** and **star-based pyramids**. The hollow forms of these were less trivial and don't fully work (polygons are ugly anyway). A corresponding warning message is sent to the player, recommending the use solid shapes with a hollow wand if they don't get the expected results.
* added an interactive clear button in the brushes list. I didn't mean to do it all in one PR, but I found the issue while doing this, sorry.
* added the new things to the documentation, and fixed a few things in `CONTRIBUTING.md` while at it.

Should we add a link to the discor dserver/channel in either readme, the docs or the contribution manual?