### PR TITLE
Cut, mirror, rotate and mirror clipboard and revolution paste

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -85,6 +85,7 @@ case it was too confusing:
    s     keep block states of replaced block, if new block matches
    g     when replacing air or water, some greenery gets repalced too
    l     when registering a brush with this flag, the brush will trace for liquids as well as blocks
+   r     remove the selection after mirroring or rotating it
    ```
    Biomes are handled by the `set_block` function, but you need to input the previous biome as a map in the `extra` 
    argument: `{'biome' -> biome}`, where the variable `biome` is the biome at the position you copied from. No need to 

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -31,7 +31,7 @@ Left clicking again will reselect the whole box.
    behind by 1 diagonal position each time
  - `/se selection move [amount] [direction]` -> Moves the selection by `amount` blocks (1 if unspecified) in the direction
    `direction` (player's main facing direction if unspecified)
- - `/se fill <block> [replacement]` -> Fills selection with `<block>`. If `[replacement]` is given, it only fills
+ - `/se set <block> [replacement]` -> Fills selection with `<block>`. If `[replacement]` is given, it only fills
     replacing that block or block tag.
  - `/se undo [moves]` -> Undoes last move performed by player or as many as specified by `[moves]`. This can be
     redone with `/se redo`.
@@ -44,17 +44,23 @@ Left clicking again will reselect the whole box.
     argument, it sets wand to specified item
  - `/se rotate <pos> <degrees> [axis]` -> Rotates selection `degrees` degrees about point `pos`. Axis must be `x`,
     `y` or `z`, defaults to `y`. NB: This will look funky if you do not use multiples of 45 or 90.
+ - `/se mirror <pos> <axes>` -> Mirrors requested `axes` of the selection with respect to `pos`. For instance, if
+    `axes` is `xz`, it will mirror the x xoordinate and the z coordinate (aka mirror with respect to the yz plane and 
+    the yx plane, respectively).
+ - `/se rotatec <degrees> [axis]` -> Rotates the clipboard by `degrees` about `axis`.
+ - `/se mirrorc <axes>` -> Mirrors the given `axes` of the clipboard. See above for more information.
  - `/se stack [stackcount] [direction]` -> Stacks selection in the direction the player is looking if not otherwise
     specfied. By defaults, it stacks one time.
  - `/se expand <pos> <magnitude>` -> Expands selection by whatever magnitude specified by player, from pos `pos`
  - `/se move <pos>` -> Moves selection to `pos`
- - `/se copy` -> Copies selection to clipboard. By default, will not override the existing clipboard (can be changed
-    by adding keyword `force`), and will also take the positions relative to position of player.
- - `/se copy <pos>` -> Copies selection to clipboard, with positions relative to `pos`. This is significant when 
-    pasting blocks, in terms of how it is pasted.
- - `/se paste` -> Pastes selection relative to player position. Be careful in case you didn't choose a wise spot
-    when making the selection.
- - `/se paste <pos>` -> Pastes selection relative to `pos`
+ - `/se copy [pos]` -> Copies selection to clipboard (including entities) setting the origin of the structure at `[pos]`, if given, or
+    the curren player position, if not. By default, will not override the existing clipboard, but you can add the keyword 
+    `froce` to repalce it.
+ - `/se cut [pos]` -> Shorthand for `copy` and the `set air`. It accepts `force` like `copy` and `flags` like `set`.
+ - `/se paste [pos]` -> Pastes selection relative to player position or to `[pos]`, if given. Be careful incase 
+    you didnt' choose a wise spot making the selection.
+ - `/se revolution paste <pos> <count> [axis]` -> Pastes the clipboard `count` times. Each successive paste operation is 
+    rotated about `axis` (default `y`) with `pos` as origin by an angle α such that α×`count` = 360º.
  - `/se flood <block>` -> Performs a flood fill (fill connex volume) within the selection and starting at the 
     player's position. Can both "fill"
     what used to be air or replace some other block.
@@ -71,11 +77,6 @@ Left clicking again will reselect the whole box.
     structure blocks.`force` will override an existing structure with the same name. Gives an error if no clipboard is 
     present. Will also copy entities.
  - `/se structure delete <name>` -> Deletes a structure file called `name`.
- - `/se copy [pos]` -> Copies selection to clipboard setting the origin of the structure at `[pos]`, if given, or
-    the curren player position, if not. By default, will not override the existing clipboard (can be changed by adding
-    keyword `force`), and will also take the positions relative to position of player.
- - `/se paste [pos]` -> Pastes selection relative to player position or to `[pos]`, if given. Be careful incase 
-    you didnt' choose a wise spot making the selection.
  - `/se flood <block>` -> Performs a flood fill (fill connex volume) within the selection and starting at the 
     player's position. Can both "fill" used to be air or replace some other block.
  - `/se flood <block> [axis]` -> Flood fill will happen only perpendicular to iven axis. Setting axis to `y`, for
@@ -161,7 +162,7 @@ Available flags:
  - `-w` -> Water-logs blocks placed in water or in other waterlogged blocks, air included
  - `-d` -> Removes water and waterlogged state from placed blocks. Applies before `-w`
  - `-p` -> Only replaces air blocks when setting an area
- - `-e` -> Copies/moves entities from old location to new location. Technically, a new entity is generated with same data
+ - `-e` -> Command will affect entities (move, copy-paste, cut, etc.). Technically, a new entity is generated with same data
     and position within the structure as the old one, so all that changes is UUID. Undoing will not remove these entities
  - `-b` -> Copies old biomes to new location.
  - `-a` -> Pasting a structure will not paste the air blocks within the structure.
@@ -170,3 +171,4 @@ Available flags:
  - `-h` -> When creating a shape, makes it hollow
  - `-l` -> When used to register a brush, the brush will targer liquids as well as blocks, instead of going right through
    them to the block behind.
+ - `-r` -> Removes blocks after mirroring or rotating them. Same as doing `cut`, `mirrorc` or `rotatec` and then `paste`

--- a/se.sc
+++ b/se.sc
@@ -56,6 +56,7 @@ base_commands_map = [
     ['rotate <pos> <degrees> <axis> f <flag>', 'rotate', false],//will replace old stuff if need be
     ['mirror <pos> <sides>', ['mirror', null], [2, 'help_cmd_mirror', 'help_cmd_mirror_tooltip', null]],//will replace old stuff if need be
     ['mirror <pos> <sides> f <flag>', 'mirror', false],//will replace old stuff if need be
+    ['mirrorc <sides>', 'mirrorc', false],//will replace old stuff if need be
     ['stack', ['stack',1,null,null], false],
     ['stack <count>', ['stack',null,null], false],
     ['stack <count> <direction>', ['stack',null], [0, 'help_cmd_stack', 'help_cmd_stack_tooltip', null]],
@@ -947,7 +948,7 @@ global_lang_keys = global_default_lang = {
     'success_redo_e' ->           'gi Successfully redid %d operations, affecting %d entities', // moves number, entities number
     'success_redo_b_and_e' ->     'gi Successfully redid %d operations, affecting %d blocks and %d entities', // moves number, blocks number, entities number
 
-
+    'mirrored_clipboard' ->       'gi Mirrored clipboard',
     'clear_clipboard' ->          'wi Cleared player %s\'s clipboard',
     'copy_clipboard_not_empty' -> 'ri Clipboard for player %s is not empty, use "/copy force" to overwrite existing clipboard data',//player
     'copy_force' ->               'ri Overwriting previous clipboard selection with new one',
@@ -2408,6 +2409,20 @@ mirror(centre, axis, flags) -> (
     );
 
     add_to_history('action_mirror', player)
+);
+
+mirrorc(axis) -> (
+
+    for(slice(global_clipboard, 1),
+        pos = _:0;
+        _mirror_pos(axis, pos) //mirrors the position in-place
+    );
+
+    for(global_clipboard:0, //mirror entities
+        _:'pos' = _mirror_pos(axis, _:'pos');
+    );
+
+    _print(player(), 'mirrored_clipboard')
 );
 
 _mirror_pos(axis, pos) -> (


### PR DESCRIPTION
This PR resolves #81 and #82. It adds
- Mirror operation
- `mirrorc` and `rotatec` command that mirror and rotata the clipboard (the default behaviour of mirror and rotate in WorldEdit).
-  `cut` command that's jsut `copy` + `set air`
-  A flag `-r` to remove the selection after rotating or mirroring it. This may be useful in some other action too, we'll see. This flag could be renamed to `-m` for "move" instead of "remove", since it's moving and rotating (or mirroring) the selection.
- Revolution paste: a short hand for `copy`, `rotatec 360/count`, `paste`, `rotatec 360/count`, `paste`, `rotatec 360/count`, `paste`, ... Looks quite cool and it's easy to implement. here's a mini demo of what it does: https://youtu.be/Z7od7NzOsqk 